### PR TITLE
refactor(SettingsNavBar): remove unused import of 'ref' from vue

### DIFF
--- a/src/components/SettingsNavBar.vue
+++ b/src/components/SettingsNavBar.vue
@@ -17,8 +17,6 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
-
 const links = [
     { to: '/settings/store', text: 'Store Settings' },
     { to: '/settings/roles', text: 'Role Management' },


### PR DESCRIPTION
The 'ref' import was not used in the component, so it was removed to clean up the code and improve maintainability.